### PR TITLE
Use unauthorized error type for recent

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -147,7 +147,7 @@ func (cnsmr *consumer) httpRecent(appGuid string, authToken string) ([]*logmessa
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusUnauthorized {
 		data, _ := ioutil.ReadAll(resp.Body)
-		return nil, errors.New(string(data))
+		return nil, NewUnauthorizedError(string(data))
 	}
 
 	if resp.StatusCode == http.StatusBadRequest {

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -403,6 +403,7 @@ var _ = Describe("Loggregator Consumer", func() {
 
 				Expect(recentError).To(HaveOccurred())
 				Expect(recentError.Error()).To(ContainSubstring("You are not authorized. Helpful message"))
+				Expect(recentError).To(BeAssignableToTypeOf(&consumer.UnauthorizedError{}))
 			})
 		})
 	})


### PR DESCRIPTION
I don't think this will solve **all** of the current problems we're seeing with the cli not refreshing the user's access token when loggregator returns us a 401, but using this same consistent error type for the return value will definitely help users of this library.

Also, I noticed that some very thoughtful developers, namely @jmtuley and @ajackson, implemented more intelligent reading of the HTTP response body  in the case of HTTP fallback that doesn't include a hardcoded buffer size. This seems like a clear win, but I was unsure if a test for this behavior would be reasonable or just bloat.
